### PR TITLE
Add docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV RAILS_SERVE_STATIC_FILES true
 ENV RAILS_LOG_TO_STDOUT true
 
 ARG BUNDLE_WITHOUT=development:test
-ARG BUNDLE_PATH=vendor/bundle
+ARG BUNDLE_PATH=/usr/bundle
 ENV BUNDLE_PATH ${BUNDLE_PATH}
 ENV BUNDLE_WITHOUT ${BUNDLE_WITHOUT}
 
@@ -47,7 +47,7 @@ FROM build_deps as gems
 RUN gem install -N bundler -v ${BUNDLER_VERSION}
 
 COPY Gemfile* ./
-RUN bundle install &&  rm -rf vendor/bundle/ruby/*/cache
+RUN bundle install &&  rm -rf /usr/bundle/ruby/*/cache
 
 FROM build_deps as node_modules
 
@@ -74,7 +74,7 @@ RUN --mount=type=cache,id=prod-apt-cache,sharing=locked,target=/var/cache/apt \
     ${PROD_PACKAGES} \
     && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
-COPY --from=gems /app /app
+COPY --from=gems /usr/bundle /usr/bundle
 COPY --from=node_modules /app/node_modules /app/node_modules
 
 ENV SECRET_KEY_BASE 1

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 ```
 git clone git@github.com:jshawl/saas-starter.git
 cd saas-starter
+docker compose up --build
 docker compose exec web bash
 ```
 
@@ -29,7 +30,7 @@ sendgrid: def456
 ```
 
 ```
-docker compose exec bundle exec rails db:create db:migrate
+docker compose exec web bin/bundle exec rails db:create db:migrate
 ```
 
 ### Running Tests

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ```
 git clone git@github.com:jshawl/saas-starter.git
 cd saas-starter
-bundle install
+docker compose exec web bash
 ```
 
 `$ EDITOR=vim rails credentials:edit` to add/edit secrets
@@ -29,7 +29,7 @@ sendgrid: def456
 ```
 
 ```
-rails db:create db:migrate
+docker compose exec bundle exec rails db:create db:migrate
 ```
 
 ### Running Tests

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Starter</title>
+    <title>SaaS Starter</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,6 +17,9 @@
 default: &default
   adapter: postgresql
   encoding: unicode
+  host: db
+  username: postgres
+  password: password
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,15 +17,15 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  host: db
-  username: postgres
-  password: password
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:
   <<: *default
+  host: db
+  username: postgres
+  password: password
   database: starter_development
 
   # The specified database role being used to connect to postgres.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  db:
+    image: postgres
+    volumes:
+      - ./tmp/db:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: password
+  web:
+    build:
+      context: .
+      args:
+        RUBY_VERSION: 3.1.1
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    volumes:
+      - .:/app
+    environment:
+      RAILS_ENV: development
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db


### PR DESCRIPTION
Technically this is not necessary but I want to do some testing of the built images from the `Dockerfile` and thought compose would be a great way to test it! 

I'll still probably work locally though (with `rvm`) but... good to have just in case someone else prefers docker as a first class citizen.